### PR TITLE
Match suggested folder paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To get best experience we recommend modifying your language specific settings. F
 
     "extensions": [ "tex" ],
     
-    "color_scheme": "Packages/Writing Color Scheme/Writing Color Scheme Light.tmTheme",
+    "color_scheme": "Packages/User/Writing Color Scheme/Writing Color Scheme Light.tmTheme",
     
     "tab_size": 4,
     "translate_tabs_to_spaces": true,


### PR DESCRIPTION
When following the steps of the README, I noticed that the path in `LaTeX.sublime-settings` didn’t match the path suggested in the guide, and so the settings did not take effect. This change reconciles the file to use the suggested path.